### PR TITLE
fix: type export missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "description": "",
   "exports": {
     "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "import": "./dist/esm/index.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
On our side it isn't picking up the types, probably because we have different typescript configurations. When I locally add this type import, it works.