### PR TITLE
fix: internal cache store is undefined by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -480,7 +480,7 @@ export class DnsCacheManager {
   }
 
   private getStaleEntry(hostname: string): DnsCache | null {
-    const entry = (this.cache as any).store.get(hostname)?.value;
+    const entry = (this.cache as any).store?.get(hostname)?.value;
     if (entry) {
       if (!entry.addresses && entry.address) {
         return {


### PR DESCRIPTION
```
@homarr/tasks:dev: Failed to resolve ::1 with TTL: No DNS records found for ::1 { label: 'DNSCache' }
@homarr/tasks:dev: DNS lookup failed for ::1, retrying (1/3) after 100ms { label: 'DNSCache', error: 'No DNS records found for ::1' }
@homarr/tasks:dev: Failed to resolve ::1 with TTL: No DNS records found for ::1 { label: 'DNSCache' }
@homarr/tasks:dev: DNS lookup failed for ::1, retrying (2/3) after 200ms { label: 'DNSCache', error: 'No DNS records found for ::1' }
@homarr/tasks:dev: Failed to resolve ::1 with TTL: No DNS records found for ::1 { label: 'DNSCache' }
@homarr/tasks:dev: DNS lookup failed for ::1, retrying (3/3) after 400ms { label: 'DNSCache', error: 'No DNS records found for ::1' }
@homarr/tasks:dev: Failed to resolve ::1 with TTL: No DNS records found for ::1 { label: 'DNSCache' }
@homarr/tasks:dev: Cached DNS lookup failed for ::1, falling back to native DNS: Cannot read properties of undefined (reading 'get') { label: 'DNSCache' }
@homarr/tasks:dev: Added new DNS cache entry for ::1 {
@homarr/tasks:dev:   label: 'DNSCache',
@homarr/tasks:dev:   addresses: { ipv4: 0, ipv6: 1 },
@homarr/tasks:dev:   activeAddress: '::1',
@homarr/tasks:dev:   family: 6
@homarr/tasks:dev: }
```

The ::1 is another thing that is a bit annoying, but I think fine for now